### PR TITLE
Upload the built jar file as a release asset

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -24,6 +24,11 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
+    - name: Upload release asset
+      uses: softprops/action-gh-release@v1
+      with:
+        files: target/*.jar
+
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:


### PR DESCRIPTION
We're running Keycloak with Docker and for us it is really convenient to add SPIs using this method:

`ADD <url-to-jar-file> /opt/jboss/keycloak/standalone/deployments`

So it would be great if there was a way to download the JAR files directly from the releases page. This action should do that, here is one example URL from my testing branch:

https://github.com/badrange/keycloak-event-listener-gcpubsub/releases/download/v1.0.1-aa/keycloak-to-gcpubsub-1.0.1.jar